### PR TITLE
Remove broken config for IPv4 + IPv6 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker run \ # or `podman` or what ever other container runtime you like
   -v /path/to/user/data:/etc/crymap/users \ # mount the user data
   -v /path/to/crymap.toml:/etc/crymap/crymap.toml \ # mount your config
   -v /path/to/privkey.pem:/config/path/to/privkey.pem \ # mount pivkey (make sure to adjust path as in your config)
-  -v /path/to/fullchain.pem:/config/path/to/fullchain.pem \ # mount fullchein (make sure to adjust path as in your config)
+  -v /path/to/fullchain.pem:/config/path/to/fullchain.pem \ # mount fullchain (make sure to adjust path as in your config)
   ghcr.io/molikuner/crymap-container:latest
 ```
 
@@ -27,8 +27,10 @@ The container is configured by default to log to stdout. If that needs to be adj
 
 ### IPv6
 
-By default the container only binds IPv4 ports. If host networking is used or the container runtime supports IPv6, simply use the `/etc/inetd46.conf` to bind to IPv4 and IPv6 addresses.
+By default the container only binds IPv4 ports. If host networking is used or the container runtime supports IPv6, simply use the `/etc/inetd6.conf` to bind to IPv4 and IPv6 addresses.
+
+Since the entrypoint of the container is `inetd` already, it's sufficient to specify the new config as command:
 
 ```shell
-docker run <...> ghcr.io/molikuner/crymap-container:latest /etc/inetd46.conf
+docker run <...> ghcr.io/molikuner/crymap-container:latest /etc/inetd6.conf
 ```

--- a/config/inetd46.conf
+++ b/config/inetd46.conf
@@ -1,8 +1,0 @@
-imaps       stream  tcp     nowait  mail    /usr/local/bin/crymap   crymap server serve-imaps
-imaps       stream  tcp6    nowait  mail    /usr/local/bin/crymap   crymap server serve-imaps
-smtp        stream  tcp     nowait  mail    /usr/local/bin/crymap   crymap server serve-smtpin
-smtp        stream  tcp6    nowait  mail    /usr/local/bin/crymap   crymap server serve-smtpin
-submissions stream  tcp     nowait  mail    /usr/local/bin/crymap   crymap server serve-smtpssub
-submissions stream  tcp6    nowait  mail    /usr/local/bin/crymap   crymap server serve-smtpssub
-submission  stream  tcp     nowait  mail    /usr/local/bin/crymap   crymap server serve-smtpsub
-submission  stream  tcp6    nowait  mail    /usr/local/bin/crymap   crymap server serve-smtpsub


### PR DESCRIPTION
While using the container in a dual-stack setup I noticed that it's sufficient to bind the IPv6 ports, as IPv4 traffic will reach the application as a translated IPv6 message. Thus using the IPv6-only config actually works for both IPv4 and IPv6.